### PR TITLE
Update install_plugin.sh remove v prefix in code too much at L64-L88

### DIFF
--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -83,6 +83,6 @@ else
     wget -q "${url}.prov" -O "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz.prov"
 fi
 #helm plugin verify "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz"
-tar xzf "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz" -C "${HELM_PLUGIN_DIR}/releases/${version}"
-mv "${HELM_PLUGIN_DIR}/releases/v${version}/cm-push/bin/helm-cm-push" "${HELM_PLUGIN_DIR}/bin/helm-cm-push" || \
-    mv "${HELM_PLUGIN_DIR}/releases/v${version}/cm-push/bin/helm-cm-push.exe" "${HELM_PLUGIN_DIR}/bin/helm-cm-push"
+tar xzf "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz" -C "${HELM_PLUGIN_DIR}/releases/${version}"
+mv "${HELM_PLUGIN_DIR}/releases/${version}/cm-push/bin/helm-cm-push" "${HELM_PLUGIN_DIR}/bin/helm-cm-push" || \
+    mv "${HELM_PLUGIN_DIR}/releases/${version}/cm-push/bin/helm-cm-push.exe" "${HELM_PLUGIN_DIR}/bin/helm-cm-push"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -62,11 +62,11 @@ esac
 
 
 if [ "$(uname)" = "Darwin" ]; then
-    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_darwin_${arch}/cm-push-v${version}.tgz"
+    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_darwin_${arch}/cm-push-${version}.tgz"
 elif [ "$(uname)" = "Linux" ] ; then
-    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_linux_${arch}/cm-push-v${version}.tgz"
+    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_linux_${arch}/cm-push-${version}.tgz"
 else
-    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_windows_${arch}/cm-push-v${version}.tgz"
+    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_windows_${arch}/cm-push-v{version}.tgz"
 fi
 
 echo $url
@@ -76,13 +76,13 @@ mkdir -p "${HELM_PLUGIN_DIR}/releases/v${version}"
 
 # Download with curl if possible.
 if [ -x "$(which curl 2>/dev/null)" ]; then
-    curl -sSL "${url}" -o "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz"
-    curl -sSL "${url}.prov" -o "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz.prov"
+    curl -sSL "${url}" -o "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz"
+    curl -sSL "${url}.prov" -o "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz.prov"
 else
-    wget -q "${url}" -O "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz"
-    wget -q "${url}.prov" -O "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz.prov"
+    wget -q "${url}" -O "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz"
+    wget -q "${url}.prov" -O "${HELM_PLUGIN_DIR}/releases/cm-push-${version}.tgz.prov"
 fi
 #helm plugin verify "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz"
-tar xzf "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz" -C "${HELM_PLUGIN_DIR}/releases/v${version}"
+tar xzf "${HELM_PLUGIN_DIR}/releases/cm-push-v${version}.tgz" -C "${HELM_PLUGIN_DIR}/releases/${version}"
 mv "${HELM_PLUGIN_DIR}/releases/v${version}/cm-push/bin/helm-cm-push" "${HELM_PLUGIN_DIR}/bin/helm-cm-push" || \
     mv "${HELM_PLUGIN_DIR}/releases/v${version}/cm-push/bin/helm-cm-push.exe" "${HELM_PLUGIN_DIR}/bin/helm-cm-push"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -72,7 +72,7 @@ fi
 echo $url
 
 mkdir -p "${HELM_PLUGIN_DIR}/bin"
-mkdir -p "${HELM_PLUGIN_DIR}/releases/v${version}"
+mkdir -p "${HELM_PLUGIN_DIR}/releases/${version}"
 
 # Download with curl if possible.
 if [ -x "$(which curl 2>/dev/null)" ]; then

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -66,7 +66,7 @@ if [ "$(uname)" = "Darwin" ]; then
 elif [ "$(uname)" = "Linux" ] ; then
     url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_linux_${arch}/cm-push-${version}.tgz"
 else
-    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_windows_${arch}/cm-push-v{version}.tgz"
+    url="https://github.com/actiancorp/helm-push/releases/download/helm-push_v${version}_windows_${arch}/cm-push-${version}.tgz"
 fi
 
 echo $url


### PR DESCRIPTION
https://github.com/ActianCorp/helm-push/blob/main/scripts/install_plugin.sh#L64-L88

in order complete release with v.0.11.6 with prefixed v in tag